### PR TITLE
docs: update README with Python version requirement (>=3.12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ git clone https://github.com/lossfunk/indiaml-tracker.git
 cd indiaml
 
 # Set up environment with uv (recommended)
-uv venv --python=3.11
+uv venv --python=3.12
 uv pip install .
 
 # Alternative setup with pip


### PR DESCRIPTION
- Clearly specify that Python 3.12 or higher is required to run the project.
- Helps prevent environment setup issues for new contributors.